### PR TITLE
Added template canonical link

### DIFF
--- a/lib/template.jade
+++ b/lib/template.jade
@@ -2,6 +2,7 @@ html
   head
     meta(charset='utf-8')
     meta(http-equiv='refresh' content='1;url=#{destination}')
+    link(rel='canonical' href=destination)
     script.
       window.location.replace('#{destination}');
   body


### PR DESCRIPTION
A link tag with a relationship of 'canonical' will be treated like a 301 redirection (moved permanently).  Better for search engines.
