### PR TITLE
Add meta tag to skip indexing

### DIFF
--- a/lib/template.jade
+++ b/lib/template.jade
@@ -2,6 +2,7 @@ doctype html
 html
   head
     meta(charset='utf-8')
+    meta(name='robots' content='noindex')
     meta(http-equiv='refresh' content='1;url=#{destination}')
     link(rel='canonical' href=destination)
     script.


### PR DESCRIPTION
I think it would be helpful if robots don't index redirect pages. For this we can add meta tag.

You can read more about it here: https://en.wikipedia.org/wiki/Noindex

Optionally this meta tag can be controlled by  options.