### PR TITLE
Fix frontmatters relative path

### DIFF
--- a/example/src/about.md
+++ b/example/src/about.md
@@ -1,0 +1,5 @@
+---
+redirectFrom: /about-me
+---
+
+This is about me.

--- a/lib/create-redirections-from-frontmatters.js
+++ b/lib/create-redirections-from-frontmatters.js
@@ -9,14 +9,14 @@ module.exports = (files, options = {}) => {
   return Object.entries(files).reduce((acc, [filepath, file]) => {
     const redirectFrom = getRedirectFrom(file)
     if (redirectFrom) {
-      for (const r of _.castArray(redirectFrom)) {
-        acc.push({ source: r, destination: filepath })
+      for (const source of _.castArray(redirectFrom)) {
+        acc.push({ source, destination: `/${filepath}` })
       }
     }
 
     const redirectTo = getRedirectTo(file)
     if (redirectTo) {
-      acc.push({ source: filepath, destination: redirectTo })
+      acc.push({ source: `/${filepath}`, destination: redirectTo })
       delete files[filepath]
     }
 

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,9 @@
 [![github](https://img.shields.io/github/issues/aymericbeaumet/metalsmith-redirect?style=flat-square&logo=github)](https://github.com/aymericbeaumet/metalsmith-redirect/issues)
 [![npm](https://img.shields.io/npm/v/metalsmith-redirect?style=flat-square&logo=npm)](https://www.npmjs.com/package/metalsmith-redirect)
 
-This plugins enables you to create HTTP redirections in your [Metalsmith](https://metalsmith.io/) website. There are several ways to do so:
+This plugins enables you to create HTTP redirections in your
+[Metalsmith](https://metalsmith.io/) website. There are several ways to do
+so:
 
 - in the plugin configuration (see
   [`options.redirections`](#optionsredirections))
@@ -56,12 +58,14 @@ metalsmith(__dirname).use(
 
 Notes:
 
-- Due to restrictions due to the client-side implementation, the **source**
+- Due to restrictions in the client-side implementation, the **source**
   must either be an HTML file, or a folder (in which case `'/index.html'` will
   be appended)
 - The **destination** can be any kind of path
 - A relative path in the **source** will be resolved based on the site root `'/'`
 - A relative path in the **destination** will be resolved based on the **source** directory
+- It is best to place this plugin in the latest position, so that the paths
+  it is dealing with have already been altered by the other plugins
 
 ### metalsmithRedirect(options)
 
@@ -109,8 +113,7 @@ Default: `false`
 
 By setting this options to `true`, this plugin will gather redirections from
 frontmatters. This feature is convenient to keep the redirections close to
-the code. You can also pass an object instead, which has the advantage to
-allow to set all the options individually.
+the code. You can also pass an object instead, see below for the nested options.
 
 <details><summary>Example: redirect from another page</summary>
 
@@ -120,7 +123,7 @@ fashion:
 
 _/photos/index.html_
 
-```html
+```markdown
 ---
 redirectFrom: /images
 ---
@@ -135,7 +138,7 @@ list to `redirectFrom`:
 
 _/photos/index.html_
 
-```html
+```markdown
 ---
 redirectFrom:
   - /images
@@ -188,7 +191,8 @@ metalsmith(__dirname).use(
 )
 ```
 
-The plugin will then look for this key in any of the frontmatters:
+The plugin will then look for the `config.redirectFrom` key in any of the
+frontmatters, like this one:
 
 ```markdown
 ---
@@ -226,7 +230,8 @@ metalsmith(__dirname).use(
 )
 ```
 
-The plugin will then look for this key in any of the frontmatters:
+The plugin will then look for the `config.redirectTo` key in any of the
+frontmatters, like this one:
 
 ```markdown
 ---
@@ -303,7 +308,7 @@ Let's consider the following configuration:
     "metalsmith-redirect": {
       "redirections": {
         "foo": "hidden.html",
-        "/foo/bar.html": "baz",
+        "/foo/bar.html": "/baz",
         "/github": "https://github.com/segmentio"
       }
     }
@@ -316,5 +321,5 @@ The following redirections would be created:
 | source               | destination                    |
 | -------------------- | ------------------------------ |
 | `/foo/index.html`    | `/foo/hidden.html`             |
-| `/foo/bar.html`      | `/foo/baz`                     |
+| `/foo/bar.html`      | `/baz`                         |
 | `/github/index.html` | `https://github.com/segmentio` |

--- a/test/index.js
+++ b/test/index.js
@@ -148,17 +148,17 @@ test.cb('metalsmith-redirect should support redirectFrom as a string', t => {
   t.plan(3)
   const plugin = metalsmithRedirect({ frontmatter: true })
   const files = {
-    '/about/index.html': {
+    'about/index.html': {
       redirectFrom: '/about-bar',
     },
   }
   plugin(files, null, () => {
     t.is(Object.keys(files).length, 2)
-    t.true('/about/index.html' in files)
+    t.true('about/index.html' in files)
     t.true(
       files['about-bar/index.html'].contents
         .toString()
-        .includes('/about/index.html')
+        .includes('href="/about/index.html"')
     )
     t.end()
   })
@@ -168,22 +168,22 @@ test.cb('metalsmith-redirect should support redirectFrom as an array', t => {
   t.plan(4)
   const plugin = metalsmithRedirect({ frontmatter: true })
   const files = {
-    '/about/index.html': {
+    'about/index.html': {
       redirectFrom: ['/about-bar', '/about-foo'],
     },
   }
   plugin(files, null, () => {
     t.is(Object.keys(files).length, 3)
-    t.true('/about/index.html' in files)
+    t.true('about/index.html' in files)
     t.true(
       files['about-bar/index.html'].contents
         .toString()
-        .includes('/about/index.html')
+        .includes('href="/about/index.html"')
     )
     t.true(
       files['about-foo/index.html'].contents
         .toString()
-        .includes('/about/index.html')
+        .includes('href="/about/index.html"')
     )
     t.end()
   })
@@ -197,17 +197,17 @@ test.cb(
       frontmatter: { redirectFrom: 'nested[0].from' },
     })
     const files = {
-      '/about/index.html': {
+      'about/index.html': {
         nested: [{ from: '/about-bar' }],
       },
     }
     plugin(files, null, () => {
       t.is(Object.keys(files).length, 2)
-      t.true('/about/index.html' in files)
+      t.true('about/index.html' in files)
       t.true(
         files['about-bar/index.html'].contents
           .toString()
-          .includes('/about/index.html')
+          .includes('href="/about/index.html"')
       )
       t.end()
     })
@@ -218,8 +218,8 @@ test.cb('metalsmith-redirect should support redirectTo as a string', t => {
   t.plan(2)
   const plugin = metalsmithRedirect({ frontmatter: true })
   const files = {
-    '/about-bar': {
-      redirectTo: '/about/index.html',
+    'about-bar': {
+      redirectTo: '/about',
     },
   }
   plugin(files, null, () => {
@@ -227,7 +227,7 @@ test.cb('metalsmith-redirect should support redirectTo as a string', t => {
     t.true(
       files['about-bar/index.html'].contents
         .toString()
-        .includes('/about/index.html')
+        .includes('href="/about"')
     )
     t.end()
   })
@@ -241,7 +241,7 @@ test.cb(
       frontmatter: { redirectTo: 'nested[0].to' },
     })
     const files = {
-      '/about-bar': {
+      'about-bar': {
         nested: [{ to: '/about/index.html' }],
       },
     }
@@ -250,7 +250,7 @@ test.cb(
       t.true(
         files['about-bar/index.html'].contents
           .toString()
-          .includes('/about/index.html')
+          .includes('href="/about/index.html"')
       )
       t.end()
     })


### PR DESCRIPTION
Closes #13

Metalsmith does not keep leading slashes in the way it represents files in memory. This causes an issue where using filepaths as either source or destination will unexpected behaviours.

This PR makes sure a leading slash is prepended when creating the redirections.